### PR TITLE
fix for warning

### DIFF
--- a/custom_components/p2000/sensor.py
+++ b/custom_components/p2000/sensor.py
@@ -61,7 +61,7 @@ class P2000Sensor(SensorEntity):
         return self._state
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return the state attributes of the monitored installation."""
         attributes = self.attributes
         attributes['icon'] = 'mdi:fire-truck'


### PR DESCRIPTION
Fix for warning: Entity sensor.p2000_renkum (<class 'custom_components.p2000.sensor.P2000Sensor'>) implements device_state_attributes.
accoording to https://github.com/home-assistant/core/pull/47304